### PR TITLE
New image for building Java projects.

### DIFF
--- a/images/java/Dockerfile
+++ b/images/java/Dockerfile
@@ -1,0 +1,21 @@
+FROM maven:3.5.3-jdk-8-slim
+
+RUN apt-get update && apt-get install -y \
+    apt-transport-https \
+    ca-certificates \
+    curl \
+    gnupg2 \
+    git \
+    software-properties-common \
+    python-setuptools \
+    python-pip
+
+RUN pip install awscli==1.15.10
+RUN curl -fsSL https://download.docker.com/linux/$(. /etc/os-release; echo "$ID")/gpg | \
+    apt-key add - && \
+    add-apt-repository \
+       "deb [arch=amd64] https://download.docker.com/linux/$(. /etc/os-release; echo "$ID") \
+       $(lsb_release -cs) \
+       stable" && \
+    apt-get update && apt-get install -y --no-install-recommends \
+    docker-ce

--- a/images_build.sh
+++ b/images_build.sh
@@ -23,6 +23,9 @@ docker push zetoltd/circleci-cordova-android:1.0.0
 docker build -t zetoltd/circleci-website:1.0.0 ./images/website/
 docker push zetoltd/circleci-website:1.0.0
 
+docker build -t zetoltd/circleci-java:1.0.0 ./images/java/
+docker push zetoltd/circleci-java:1.0.0
+
 # Lifted from doc.ai fork of original docker image from Sendgridlabs
 docker build -t zetoltd/loggly:1.0.0 ./images/loggly/
 docker build -t zetoltd/loggly:latest ./images/loggly/


### PR DESCRIPTION
Used in CircleCI 2.0 migration of keycloak-cluster.
Note that [the changes](https://github.com/Zeto-Ltd/keycloak-cluster/compare/e1ee85f57fa8e5a6d2f5ecb0c200488f5e181c8f...08df51e03e91c23d716d59ca67c68398efab87ba) there were committed to master.