### PR TITLE
Nginx for ELB

### DIFF
--- a/images/devbox/Dockerfile
+++ b/images/devbox/Dockerfile
@@ -50,6 +50,8 @@ RUN apt update && apt install -y \
 
 COPY bashrc ${DEV_HOME}/.bashrc
 COPY profile ${DEV_HOME}/.profile
+ARG USER_UID
+ARG USER_GID
 # adding user 'dev' that matches host gid/uid with password of 'dev'
 # + sane tmux configuration
 ENV TMUX_MODIFIER C-q

--- a/images/nginx-elb/Dockerfile
+++ b/images/nginx-elb/Dockerfile
@@ -1,0 +1,6 @@
+FROM nginx:1.15.1-alpine
+
+COPY nginx.conf /etc/nginx/nginx.conf
+COPY website.conf /etc/nginx/conf.d/default.conf
+
+EXPOSE 8001

--- a/images/nginx-elb/nginx.conf
+++ b/images/nginx-elb/nginx.conf
@@ -1,0 +1,31 @@
+user  nginx;
+worker_processes  1;
+
+error_log  /dev/null warn;
+pid        /var/run/nginx.pid;
+
+
+events {
+    worker_connections  1024;
+}
+
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /dev/null main;
+
+    sendfile        on;
+    #tcp_nopush     on;
+
+    keepalive_timeout  180;
+
+    #gzip  on;
+
+    include /etc/nginx/conf.d/*.conf;
+}

--- a/images/nginx-elb/website.conf
+++ b/images/nginx-elb/website.conf
@@ -12,9 +12,10 @@ server {
     # Instead, force the host to a specific value for the health check
     # before passing through the request to the Django backend
     location /health {
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_set_header Host "elb.amazonaws.com";
+        proxy_set_header X-Forwarded-For "";
+        proxy_set_header X-Forwarded-Host "";
+        proxy_set_header X-Forwarded-Proto "";
+        proxy_set_header Host "amazonaws.health";
         proxy_redirect off;
         proxy_pass http://app_server;
     }

--- a/images/nginx-elb/website.conf
+++ b/images/nginx-elb/website.conf
@@ -1,0 +1,21 @@
+upstream app_server {
+    # fail_timeout=0 means we always retry an upstream even if it failed
+    # to return a good HTTP response
+    server 0.0.0.0:8000 fail_timeout=0;
+}
+
+server {
+    listen       *:8001;
+
+    # for AWS ECS health checks, the IP address of the ECS instance is used,
+    # which doesn't work with Django's sites framework for multi-tenanting.
+    # Instead, force the host to a specific value for the health check
+    # before passing through the request to the Django backend
+    location /health {
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Host "elb.amazonaws.com";
+        proxy_redirect off;
+        proxy_pass http://app_server;
+    }
+}

--- a/images_build.sh
+++ b/images_build.sh
@@ -38,6 +38,9 @@ docker push zetoltd/loggly:latest
 docker build -t zetoltd/circleci-frontend:1.0.0 ./images/frontend/
 docker push zetoltd/circleci-frontend:1.0.0
 
+docker build -t zetoltd/nginx-elb:1.0.0 ./images/nginx-elb/
+docker push zetoltd/nginx-elb:1.0.0
+
 docker build -t zetoltd/chronos:1.0.0 ./images/chronos/
 docker push zetoltd/chronos:1.0.0
 


### PR DESCRIPTION
ELB has a bad limitation that the host header is set to the ECS instance IP. This is a problem for Django when using both the ALLOWED_HOSTS setting and the sites framework. Created simple container that acts as proxy for ELB health checks and sets a fixed host header before passing on the request.

Also fixed bug with devbox image to enable custom user ID and group ID.